### PR TITLE
Add configurable minute timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,11 +80,20 @@
       <span class="btn message">さっそく開発する</span>
     </div>
   </div>
+  <div class="timer-wrapper">
+    <div class="container">
+      <h2>タイマー</h2>
+      <input id="minutes" type="number" min="1" max="60" value="1"> 分
+      <button id="start-button">スタート</button>
+      <div id="timer-display">00:00</div>
+    </div>
+  </div>
   <footer>
     <div class="container">
       <img src="https://prog-8.com/images/html/advanced/footer_logo.png">
       <p>Learn to Code, Learn to be Creative.</p>
     </div>
   </footer>
+  <script src="timer.js"></script>
 </body>
 </html>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -177,6 +177,16 @@ header {
   box-shadow: none;
 }
 
+.timer-wrapper {
+  padding: 40px 0;
+  text-align: center;
+}
+
+#timer-display {
+  font-size: 32px;
+  margin-top: 20px;
+}
+
 footer img {
   width: 125px;
 }

--- a/timer.js
+++ b/timer.js
@@ -1,0 +1,26 @@
+let intervalId;
+
+function updateDisplay(seconds) {
+  const m = String(Math.floor(seconds / 60)).padStart(2, '0');
+  const s = String(seconds % 60).padStart(2, '0');
+  document.getElementById('timer-display').textContent = `${m}:${s}`;
+}
+
+document.getElementById('start-button').addEventListener('click', function() {
+  const minutesInput = document.getElementById('minutes');
+  const minutes = parseInt(minutesInput.value, 10);
+  if (isNaN(minutes) || minutes < 1 || minutes > 60) {
+    return;
+  }
+  let remaining = minutes * 60;
+  updateDisplay(remaining);
+  clearInterval(intervalId);
+  intervalId = setInterval(() => {
+    remaining--;
+    updateDisplay(remaining);
+    if (remaining <= 0) {
+      clearInterval(intervalId);
+      alert('時間になりました');
+    }
+  }, 1000);
+});


### PR DESCRIPTION
## Summary
- add timer section with minute selection and start button
- display countdown using new timer.js script
- style timer elements for centered layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896df15ee848331ae6c4d03b42768b4